### PR TITLE
Hide valkeyNetRead & valkeyNetWrite

### DIFF
--- a/include/valkey/net.h
+++ b/include/valkey/net.h
@@ -38,8 +38,6 @@
 #include "valkey.h"
 
 void valkeyNetClose(valkeyContext *c);
-ssize_t valkeyNetRead(valkeyContext *c, char *buf, size_t bufcap);
-ssize_t valkeyNetWrite(valkeyContext *c);
 
 int valkeyCheckSocketError(valkeyContext *c);
 int valkeyContextSetTimeout(valkeyContext *c, const struct timeval tv);

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -42,17 +42,7 @@
 #include "valkey_private.h"
 #include "net.h"
 #include "sds.h"
-#include "async.h"
 #include "win32.h"
-
-static valkeyContextFuncs valkeyContextDefaultFuncs = {
-    .close = valkeyNetClose,
-    .free_privctx = NULL,
-    .async_read = valkeyAsyncRead,
-    .async_write = valkeyAsyncWrite,
-    .read = valkeyNetRead,
-    .write = valkeyNetWrite
-};
 
 static valkeyReply *createReplyObject(int type);
 static void *createStringObject(const valkeyReadTask *task, char *str, size_t len);
@@ -718,7 +708,7 @@ static valkeyContext *valkeyContextInit(void) {
     if (c == NULL)
         return NULL;
 
-    c->funcs = &valkeyContextDefaultFuncs;
+    valkeyContextSetDefaultFuncs(c);
 
     c->obuf = sdsempty();
     c->reader = valkeyReaderCreate();

--- a/src/valkey_private.h
+++ b/src/valkey_private.h
@@ -122,4 +122,6 @@ static inline int valkeyContextUpdateCommandTimeout(valkeyContext *c,
     return VALKEY_OK;
 }
 
+void valkeyContextSetDefaultFuncs(valkeyContext *c);
+
 #endif  /* VALKEY_VK_PRIVATE_H */


### PR DESCRIPTION
Move valkeyContextDefaultFuncs into net.c, then valkeyNetRead & valkeyNetWrite could be declared as static functions.

async.h is no longer needed by valkey.c, that makes valkey.c independent from networking IO specific operations.